### PR TITLE
Fix retours projet

### DIFF
--- a/lib/scrumboard.lib.php
+++ b/lib/scrumboard.lib.php
@@ -99,7 +99,7 @@ function scrum_getAllStories($fk_project) {
 function scrum_getStorie($fk_project, $storie_k) {
 	global $db;
 
-	$sql = 'SELECT label';
+	$sql = 'SELECT label, date_start, date_end';
 	$sql .= ' FROM '.MAIN_DB_PREFIX.'projet_storie';
 	$sql .= " WHERE fk_projet=$fk_project";
 	$sql .= " AND storie_order=$storie_k";
@@ -107,18 +107,30 @@ function scrum_getStorie($fk_project, $storie_k) {
 	$resql = $db->query($sql);
 
 	if($obj = $db->fetch_object($resql)) {
-		return $obj->label;
+		if(empty($obj->date_start)) $date_start = -1;
+		else $date_start = $obj->date_start;
+
+		if(empty($obj->date_end)) $date_end = -1;
+		else $date_end = $obj->date_end;
+
+		return array('label' => $obj->label, 'date_start' => $date_start, 'date_end' => $date_end);
 	}
-	return '';
+	return array();
 }
 
 function scrum_updateStorie($fk_project, $storie_k, $storie_label, $date_start, $date_end) {
 	global $db;
 	
+	if(empty($date_start)) $storie_date_start = 'NULL';
+	else $storie_date_start = '"'.date('Y-m-d', strtotime(preg_replace('/\//', '-', $date_start))).'"';
+
+	if(empty($date_end)) $storie_date_end = 'NULL';
+	else $storie_date_end = '"'.date('Y-m-d', strtotime(preg_replace('/\//', '-', $date_end))).'"';
+
 	$sql = 'UPDATE '.MAIN_DB_PREFIX.'projet_storie';
 	$sql .= " SET label='$storie_label',";
-	$sql .= ' date_start="'.date('Y-m-d', strtotime(preg_replace('/\//', '-', $date_start))).'",';
-	$sql .= ' date_end="'.date('Y-m-d', strtotime(preg_replace('/\//', '-', $date_end))).'"';
+	$sql .= ' date_start='.$storie_date_start.',';
+	$sql .= ' date_end='.$storie_date_end.',';
 	$sql .= " WHERE fk_projet=$fk_project";
 	$sql .= " AND storie_order=$storie_k";
 
@@ -136,14 +148,14 @@ function scrum_deleteStorie($fk_project, $storie_k) {
 	$db->query($sql);
 }
 
-function scrum_addStorie($fk_project, $storie_order, $storie_name, $storie_date_start = '', $storie_date_end = '') {
+function scrum_addStorie($fk_project, $storie_order, $storie_name, $date_start = '', $date_end = '') {
 	global $db;
 
-	if(empty($storie_date_start)) $storie_date_start = 'NULL';
-	else $storie_date_start = '"'.date('Y-m-d', strtotime(preg_replace('/\//', '-', $storie_date_start))).'"';
+	if(empty($date_start)) $storie_date_start = 'NULL';
+	else $storie_date_start = '"'.date('Y-m-d', strtotime(preg_replace('/\//', '-', $date_start))).'"';
 
-	if(empty($storie_date_end)) $storie_date_end = 'NULL';
-	else $storie_date_end = '"'.date('Y-m-d', strtotime(preg_replace('/\//', '-', $storie_date_end))).'"';
+	if(empty($date_end)) $storie_date_end = 'NULL';
+	else $storie_date_end = '"'.date('Y-m-d', strtotime(preg_replace('/\//', '-', $date_end))).'"';
 
 	$sql = 'INSERT INTO '.MAIN_DB_PREFIX.'projet_storie(fk_projet, storie_order, label, date_start, date_end)';
 	$sql .= " VALUES($fk_project, $storie_order, '$storie_name', $storie_date_start, $storie_date_end)";

--- a/script/migration_stories.php
+++ b/script/migration_stories.php
@@ -27,7 +27,7 @@ dol_include_once('/scrumboard/lib/scrumboard.lib.php');
 /**
  * Actions
  */
-global $db;
+global $db, $langs;
 
 $error = 0;
 $TData = getData();
@@ -35,12 +35,21 @@ $TData = getData();
 foreach($TData as $fk_project => $stories) {
 	$TStorieLabel = explode(',', $stories);
 
-	foreach($TStorieLabel as $k => $storie_label) {
+	if(empty($TStorieLabel)) {
 		$sql = 'INSERT INTO '.MAIN_DB_PREFIX.'projet_storie(fk_projet, storie_order, label)';
-		$sql .= ' VALUES('.$fk_project.', '.($k+1).', "'.ltrim($storie_label).'")';
+		$sql .= ' VALUES('.$fk_project.', 1, "'.$langs->trans('Tasks').'")';
 
 		$resql = $db->query($sql);
 		if(! $resql) $error++;
+	}
+	else {
+		foreach($TStorieLabel as $k => $storie_label) {
+			$sql = 'INSERT INTO '.MAIN_DB_PREFIX.'projet_storie(fk_projet, storie_order, label)';
+			$sql .= ' VALUES('.$fk_project.', '.($k+1).', "'.ltrim($storie_label).'")';
+
+			$resql = $db->query($sql);
+			if(! $resql) $error++;
+		}
 	}
 }
 
@@ -61,7 +70,7 @@ function getData() {
 
 	$sql = 'SELECT fk_object, stories';
 	$sql .= ' FROM '.MAIN_DB_PREFIX.'projet_extrafields';
-	$sql .= ' WHERE stories IS NOT NULL';
+//	$sql .= ' WHERE stories IS NOT NULL';
 
 	$resql = $db->query($sql);
 

--- a/script/migration_stories.php
+++ b/script/migration_stories.php
@@ -27,7 +27,7 @@ dol_include_once('/scrumboard/lib/scrumboard.lib.php');
 /**
  * Actions
  */
-global $db, $langs;
+global $db;
 
 $error = 0;
 $TData = getData();
@@ -37,7 +37,7 @@ foreach($TData as $fk_project => $stories) {
 
 	if(empty($TStorieLabel)) {
 		$sql = 'INSERT INTO '.MAIN_DB_PREFIX.'projet_storie(fk_projet, storie_order, label)';
-		$sql .= ' VALUES('.$fk_project.', 1, "'.$langs->trans('Tasks').'")';
+		$sql .= ' VALUES('.$fk_project.', 1, "Sprint 1")';
 
 		$resql = $db->query($sql);
 		if(! $resql) $error++;

--- a/scrum.php
+++ b/scrum.php
@@ -199,6 +199,8 @@ td.projectDrag {
 		?>
 			<?php
 				if($action == 'edit' && $storie_k == $storie_k_toEdit) {
+					$TStorieElem = scrum_getStorie($id_projet, $storie_k);
+
 					print '<form action="'.$_SERVER['PHP_SELF'].'" method="POST">';
 					print '<input type="hidden" name="id" value="'.$id_projet.'" />';
 					print '<input type="hidden" name="action" value="save" />';
@@ -207,15 +209,15 @@ td.projectDrag {
 					print '<tr>';
 					
 					print '<td>';
-					print '<input type="text" name="storieName" storie-k="'.$storie_k.'" value="'.scrum_getStorie($id_projet, $storie_k).'"/>';
+					print '<input type="text" name="storieName" storie-k="'.$storie_k.'" value="'.$TStorieElem['label'].'"/>';
 					print '</td>';
 					
 					print '<td>';
 					print $langs->trans('From').' : ';
-					print $form->select_date($storie_date_start, 'storie_date_start');
+					print $form->select_date($TStorieElem['date_start'], 'storie_date_start');
 					print '&nbsp;';
 					print $langs->trans('to').' : ';
-					print $form->select_date($storie_date_end, 'storie_date_end');
+					print $form->select_date($TStorieElem['date_end'], 'storie_date_end');
 					print '</td>';
 					
 					print '<td colspan="'.($nbColumns-3).'"></td>';

--- a/scrum.php
+++ b/scrum.php
@@ -221,7 +221,7 @@ td.projectDrag {
 					print '<td colspan="'.($nbColumns-3).'"></td>';
 					
 					print '<td align="right">';
-					print '<input type="submit" name="submit" value="'.$langs->trans('Save').'" />';
+					print '<input type="submit" name="submit" value="'.$langs->trans('Save').'" class="button" />';
 					print '</td>';
 					
 					print '</tr>';
@@ -418,10 +418,10 @@ td.projectDrag {
 			<?php
 
 			print '<span>'.$langs->trans('From').' : </span>';
-			print $form->select_date('', 'add_storie_date_start');
+			print $form->select_date(-1, 'add_storie_date_start');
 			
 			print '<span>'.$langs->trans('to').' : </span>';
-			print $form->select_date('', 'add_storie_date_end');
+			print $form->select_date(-1, 'add_storie_date_end');
 
 			?>
 

--- a/scrum.php
+++ b/scrum.php
@@ -95,7 +95,7 @@
 		 */
 		print '<table class="border" width="100%">';
 
-		$linkback = '<a href="'.DOL_URL_ROOT.'/projet/liste.php">'.$langs->trans("BackToList").'</a>';
+		$linkback = '<a href="'.DOL_URL_ROOT.'/projet/list.php">'.$langs->trans("BackToList").'</a>';
 
 		// Ref
 		print '<tr><td width="30%">'.$langs->trans('Ref').'</td><td colspan="3">';


### PR DESCRIPTION
- Correction du fichier de migration qui ne créait pas de sprint pour un projet si celui-ci n'utilisait pas l'extrafield "Histoires planifiées"
- Ajout de la classe "button" sur l'input de modification d'un sprint
- Correction de l'édition des dates des sprints qui étaient incohérentes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_scrumboard/23)
<!-- Reviewable:end -->
