### PR TITLE
FIX: bring global scrumboard back from the dead

### DIFF
--- a/class/scrumboard.class.php
+++ b/class/scrumboard.class.php
@@ -137,7 +137,13 @@ class TStory extends TObjetStd {
 	function getAllStoriesFromProject($fk_project) {
 		$PDOdb = new TPDOdb;
 
-		$TConditions = array('fk_projet' => $fk_project);
+		$TConditions = array();
+
+		if(! empty($fk_project))
+		{
+			$TConditions = array('fk_projet' => $fk_project);
+		}
+
 		$TRes = parent::LoadAllBy($PDOdb, $TConditions);
 		usort($TRes, array($this, 'orderByStoryOrder'));
 		return $TRes;
@@ -145,8 +151,11 @@ class TStory extends TObjetStd {
 
 	private function orderByStoryOrder($a, $b)
 	{
+		if ($a->fk_projet < $b->fk_projet) return -1;
+		if ($a->fk_projet > $b->fk_projet) return 1;
+
 		if ($a->storie_order < $b->storie_order) return -1;
-		elseif ($a->storie_order > $b->storie_order) return 1;
+		if ($a->storie_order > $b->storie_order) return 1;
 
 		return 0;
 	}

--- a/langs/fr_FR/scrumboard.lang
+++ b/langs/fr_FR/scrumboard.lang
@@ -18,7 +18,7 @@ ResetDateTask=Recalculer les dates des tâches
 
 ProjectStories=Histoires planifiées (séparées par des virgules)
 
-EnableFilterOnGlobalView=Activer le filtre par utilisateur sur la vue global
+EnableFilterOnGlobalView=Activer le filtre par utilisateur
 
 NumberOfWorkingHourInDay=Nombre d'heures travaillées par jour
 AllowCompleteModeBacklog=Ajoute 2 colonnes supplémentaires sur la vue scrumboard (backlog et review)

--- a/script/interface.php
+++ b/script/interface.php
@@ -348,7 +348,20 @@ function _tasks(&$db, $id_project, $status, $fk_user) {
 	global $user,$conf;
 	dol_include_once('scrumboard/class/scrumboard.class.php');
 	
-	$sql = 'SELECT DISTINCT pt.rowid, pt.story_k, pt.scrum_status, pt.rang FROM '.MAIN_DB_PREFIX.'projet_task pt';
+	$sql = 'SELECT DISTINCT pt.rowid, pt.story_k, pt.scrum_status, pt.rang';
+
+	if(empty($id_project) && $status != 'unknownColumn')
+	{
+		$sql.= ', ps.rowid as story_id';
+	}
+
+	$sql.= ' FROM '.MAIN_DB_PREFIX.'projet_task pt';
+
+	if(empty($id_project) && $status != 'unknownColumn')
+	{
+		$sql.= ' INNER JOIN ' . MAIN_DB_PREFIX . 'projet_storie ps ON (ps.fk_projet = pt.fk_projet AND ps.storie_order IN (0, pt.story_k))';
+	}
+
 	if (!empty($conf->global->SCRUM_FILTER_BY_USER_ENABLE) && $fk_user > 0)
 	{
 		$sql.= ' INNER JOIN '.MAIN_DB_PREFIX.'element_contact ec ON (ec.element_id = pt.rowid)';
@@ -373,7 +386,7 @@ function _tasks(&$db, $id_project, $status, $fk_user) {
 		else if($status=='finish') $sql.= ' OR (scrum_status IS NULL AND  progress=100)';
 		$sql .= ')';
 	}
-	
+
 	/** ORIGINE ***/
 //	if($status=='ideas') {
 //		$sql.= ' WHERE  (progress = 0 OR progress IS NULL) AND datee IS NULL';
@@ -403,7 +416,7 @@ function _tasks(&$db, $id_project, $status, $fk_user) {
 	$TTask = array();
 	while($obj = $db->fetch_object($res)) {
 		if($status == 'unknownColumn') $obj->scrum_status = $defaultColumn;
-		$TTask[] = array_merge( _task($db, $obj->rowid) , array('status'=>$status,'story_k'=>$obj->story_k,'scrum_status'=>$obj->scrum_status));
+		$TTask[] = array_merge( _task($db, $obj->rowid) , array('status'=>$status,'story_k'=>$obj->story_k, 'story_id'=>$obj->story_id,'scrum_status'=>$obj->scrum_status));
 	}
 	
 	return $TTask;

--- a/script/interface.php
+++ b/script/interface.php
@@ -348,18 +348,12 @@ function _tasks(&$db, $id_project, $status, $fk_user) {
 	global $user,$conf;
 	dol_include_once('scrumboard/class/scrumboard.class.php');
 	
-	$sql = 'SELECT DISTINCT pt.rowid, pt.story_k, pt.scrum_status, pt.rang';
+	$sql = 'SELECT DISTINCT pt.rowid, pt.story_k, pt.scrum_status, pt.rang
+			FROM '.MAIN_DB_PREFIX.'projet_task pt';
 
 	if(empty($id_project) && $status != 'unknownColumn')
 	{
-		$sql.= ', ps.rowid as story_id';
-	}
-
-	$sql.= ' FROM '.MAIN_DB_PREFIX.'projet_task pt';
-
-	if(empty($id_project) && $status != 'unknownColumn')
-	{
-		$sql.= ' INNER JOIN ' . MAIN_DB_PREFIX . 'projet_storie ps ON (ps.fk_projet = pt.fk_projet AND ps.storie_order IN (0, pt.story_k))';
+		$sql.= ' INNER JOIN ' . MAIN_DB_PREFIX . 'projet_storie ps ON (ps.fk_projet = pt.fk_projet AND ps.storie_order = pt.story_k)';
 	}
 
 	if (!empty($conf->global->SCRUM_FILTER_BY_USER_ENABLE) && $fk_user > 0)
@@ -416,7 +410,7 @@ function _tasks(&$db, $id_project, $status, $fk_user) {
 	$TTask = array();
 	while($obj = $db->fetch_object($res)) {
 		if($status == 'unknownColumn') $obj->scrum_status = $defaultColumn;
-		$TTask[] = array_merge( _task($db, $obj->rowid) , array('status'=>$status,'story_k'=>$obj->story_k, 'story_id'=>$obj->story_id,'scrum_status'=>$obj->scrum_status));
+		$TTask[] = array_merge( _task($db, $obj->rowid) , array('status'=>$status,'story_k'=>$obj->story_k,'scrum_status'=>$obj->scrum_status));
 	}
 	
 	return $TTask;

--- a/script/scrum.js.php
+++ b/script/scrum.js.php
@@ -78,12 +78,12 @@ function project_get_tasks(id_project, status) {
 				print 'l_status = "'.$scrumColumn->getDefaultColumn().'";';
 				?>
 			}
-			
-			if($('tr[story-k='+task.story_k+']').length>0) {
-				$ul = $('tr[story-k='+task.story_k+']').find('ul[rel="'+l_status+'"]');
+
+			if($('tr[project-id='+task.fk_project+'][story-k='+task.story_k+']').length>0) {
+				$ul = $('tr[project-id='+task.fk_project+'][story-k='+task.story_k+']').find('ul[rel="'+l_status+'"]');
 			}
 			else{
-				$ul = $('tr[default-k=1]').find('ul[rel="'+l_status+'"]');
+				$ul = $('tr[project-id='+task.fk_project+'][default-k=1]').find('ul[rel="'+l_status+'"]');
 			}
 
 			project_draw_task(id_project, task, $ul);

--- a/scrum.php
+++ b/scrum.php
@@ -100,8 +100,6 @@
 	dol_fiche_head($head, 'scrumboard', $langs->trans("Scrumboard"),0,($object->public?'projectpub':'project'));
 
 	$form = new Form($db);
-
-	$userFilter = '';
 	
 	if($id_projet) {
 		
@@ -259,7 +257,6 @@ td.projectDrag {
 		$currentProject = 0;
 		foreach($TStorie as &$obj) {
 			$storie_k = $obj->storie_order;
-			$story_id = $obj->getId();
 
 			if(empty($id_projet) && $currentProject != $obj->fk_projet)
 			{
@@ -347,12 +344,12 @@ td.projectDrag {
 					print '</td>';
       ?></tr>
           <?php } ?>
-		<tr class="hiddable" project-id="<?php echo ($id_projet > 0 ? $id_projet : $currentProject); ?>" story-id="<?php echo $story_id; ?>" story-k="<?php echo $storie_k; ?>" default-k="<?php echo $default_k; ?>" style="<?php if(! $obj->visible) echo 'display: none;';?>">
+		<tr class="hiddable" project-id="<?php echo ($id_projet > 0 ? $id_projet : $currentProject); ?>" story-k="<?php echo $storie_k; ?>" default-k="<?php echo $default_k; ?>" style="<?php if(! $obj->visible) echo 'display: none;';?>">
 			<?php
 			foreach($TColumn as $column) {
 				echo '<td class="projectDrag droppable" data-code="'.$column->code.'" rel="'.$column->code.'">';
 
-				echo '<ul class="task-list" data-code="'.$column->code.'" data-project-id="'.($id_projet > 0 ? $id_projet : $currentProject).'" data-story-id="' . $story_id . '" data-story-k="'.$storie_k.'" rel="'.$column->code.'" story-k="'.$storie_k.'">';
+				echo '<ul class="task-list" data-code="'.$column->code.'" data-project-id="'.($id_projet > 0 ? $id_projet : $currentProject).'" data-story-k="'.$storie_k.'" rel="'.$column->code.'" story-k="'.$storie_k.'">';
 				echo '</ul>';
 
 				echo '</td>';

--- a/scrum.php
+++ b/scrum.php
@@ -100,6 +100,8 @@
 	dol_fiche_head($head, 'scrumboard', $langs->trans("Scrumboard"),0,($object->public?'projectpub':'project'));
 
 	$form = new Form($db);
+
+	$userFilter = '';
 	
 	if($id_projet) {
 		
@@ -198,29 +200,21 @@
 		print '<div class="underbanner clearboth"></div>';
 		print '<table class="border" width="100%">';
 
-		if (!empty($conf->global->SCRUM_FILTER_BY_USER_ENABLE))
-		{
-			echo '<tr><td>';
-			echo $langs->trans('UserFilter');
-			echo '</td><td>';
-			$fk_user = GETPOST('fk_user');
-			if ($id_projet == 0 && empty($fk_user)) $fk_user = $user->id; // Si on selectionne vide dans le champ on aura -1
-
-			echo '<form action="'.$_SERVER['PHP_SELF'].'" method="POST" id="scrum_filter_by_user">';
-			echo '<input name="id" value="'.$id_projet.'" type="hidden" />';
-			echo $form->select_dolusers($fk_user, 'fk_user',  1);
-			echo '<input type="submit" value="'.$langs->trans('Filter').'" class="butAction" />';
-			echo '</form>';
-			echo '</td></tr>';
-		}
+		_printUserFilter($id_projet, $form);
 
 		print '</table>';
 		print '</div>';
 		print '</div>';
-	
 	}
 	else{
-		print $langs->trans("CurrentVelocity").' <span rel="currentVelocity"></span>';	
+		print '<table class="border" width="100%">';
+		echo '<tr><td>';
+		echo $langs->trans('CurrentVelocity');
+		echo '</td><td rel="currentVelocity"></td></tr>';
+
+		_printUserFilter($id_projet, $form);
+
+		print '</table>';
 	}
 
 	$TStorie = $story->getAllStoriesFromProject($id_projet);
@@ -262,9 +256,19 @@ td.projectDrag {
 		<?php 
 		$default_k = 1;
 		$storie_k = 0;
+		$currentProject = 0;
 		foreach($TStorie as &$obj) {
 			$storie_k = $obj->storie_order;
+			$story_id = $obj->getId();
 
+			if(empty($id_projet) && $currentProject != $obj->fk_projet)
+			{
+				$projet = new Project($db);
+				$projet->fetch($obj->fk_projet);
+				print '<tr><td colspan="' . $nbColumns . '" style="font-size:140%">'.$projet->getNomUrl(1).'</td></tr>';
+				$currentProject = $projet->id;
+				$default_k = 1;
+			}
 		?>
 			<?php
 				if($action == 'edit' && $storie_k == $storie_k_toEdit) {
@@ -317,13 +321,16 @@ td.projectDrag {
 			<?php
                     if($nbColumns > 3) print '<td colspan="'.($nbColumns-3).'"></td>';
 					print '<td align="right">';
-					print '<a href="'.$_SERVER['PHP_SELF'].'?id='.$id_projet.'&storie_k='.$storie_k.'&action=edit">'.img_picto($langs->trans('Modify'), 'edit.png').'</a>';
 
-					print '&nbsp;';
-					if($storie_k != 1) {
-						print '<a href="'.$_SERVER['PHP_SELF'].'?id='.$id_projet.'&storie_k='.$storie_k.'&action=confirm_delete">'.img_picto($langs->trans('Delete'), 'delete.png').'</a>';
+					if($id_projet > 0)
+					{
+						print '<a href="'.$_SERVER['PHP_SELF'].'?id='.$id_projet.'&storie_k='.$storie_k.'&action=edit">'.img_picto($langs->trans('Modify'), 'edit.png').'</a>';
+
+						print '&nbsp;';
+						if($storie_k != 1) {
+							print '<a href="'.$_SERVER['PHP_SELF'].'?id='.$id_projet.'&storie_k='.$storie_k.'&action=confirm_delete">'.img_picto($langs->trans('Delete'), 'delete.png').'</a>';
+						}
 					}
-
 					print '<a href="javascript:toggle_visibility('.$id_projet.', '.$storie_k.')">';
 
 					if($obj->visible) {
@@ -340,12 +347,12 @@ td.projectDrag {
 					print '</td>';
       ?></tr>
           <?php } ?>
-		<tr class="hiddable" story-k="<?php echo $storie_k; ?>" default-k="<?php echo $default_k; ?>" style="<?php if(! $obj->visible) echo 'display: none;';?>">
+		<tr class="hiddable" project-id="<?php echo ($id_projet > 0 ? $id_projet : $currentProject); ?>" story-id="<?php echo $story_id; ?>" story-k="<?php echo $storie_k; ?>" default-k="<?php echo $default_k; ?>" style="<?php if(! $obj->visible) echo 'display: none;';?>">
 			<?php
 			foreach($TColumn as $column) {
 				echo '<td class="projectDrag droppable" data-code="'.$column->code.'" rel="'.$column->code.'">';
 
-				echo '<ul class="task-list" data-code="'.$column->code.'" data-story-k="'.$storie_k.'" rel="'.$column->code.'" story-k="'.$storie_k.'">';
+				echo '<ul class="task-list" data-code="'.$column->code.'" data-project-id="'.($id_projet > 0 ? $id_projet : $currentProject).'" data-story-id="' . $story_id . '" data-story-k="'.$storie_k.'" rel="'.$column->code.'" story-k="'.$storie_k.'">';
 				echo '</ul>';
 
 				echo '</td>';
@@ -363,47 +370,51 @@ td.projectDrag {
 	/*
 	 * Actions
 	*/
-	print '<div class="tabsAction">';
 
-	if ($user->rights->projet->all->creer || $user->rights->projet->creer)
+	if($id_projet > 0)
 	{
-		if ($object->public || $object->restrictedProjectArea($user,'write') > 0)
-		{
-			print '<a class="butAction" href="javascript:add_storie_task('.$object->id.');">'.$langs->trans('AddStorieTask').'</a>';
-		}
-		else
-		{
-			print '<a class="butActionRefused" href="#" title="'.$langs->trans("NotOwnerOfProject").'">'.$langs->trans('AddStorieTask').'</a>';
-		}
-	}
+		print '<div class="tabsAction">';
 
-	if( (float)DOL_VERSION > 3.4 ) {
 		if ($user->rights->projet->all->creer || $user->rights->projet->creer)
 		{
 			if ($object->public || $object->restrictedProjectArea($user,'write') > 0)
 			{
-				print '<a class="butAction" href="javascript:reset_date_task('.$object->id.');">'.$langs->trans('ResetDateTask').'</a>';
+				print '<a class="butAction" href="javascript:add_storie_task('.$object->id.');">'.$langs->trans('AddStorieTask').'</a>';
+			}
+			else
+			{
+				print '<a class="butActionRefused" href="#" title="'.$langs->trans("NotOwnerOfProject").'">'.$langs->trans('AddStorieTask').'</a>';
 			}
 		}
-	}
 
-	if (($user->rights->projet->all->creer || $user->rights->projet->creer) && $id_projet)
-	{
-		if ($object->public || $object->restrictedProjectArea($user,'write') > 0)
+		if( (float)DOL_VERSION > 3.4 ) {
+			if ($user->rights->projet->all->creer || $user->rights->projet->creer)
+			{
+				if ($object->public || $object->restrictedProjectArea($user,'write') > 0)
+				{
+					print '<a class="butAction" href="javascript:reset_date_task('.$object->id.');">'.$langs->trans('ResetDateTask').'</a>';
+				}
+			}
+		}
+
+		if (($user->rights->projet->all->creer || $user->rights->projet->creer))
 		{
-			print '<a class="butAction" href="javascript:create_task('.$object->id.');">'.$langs->trans('AddTask').'</a>';
+			if ($object->public || $object->restrictedProjectArea($user,'write') > 0)
+			{
+				print '<a class="butAction" href="javascript:create_task('.$object->id.');">'.$langs->trans('AddTask').'</a>';
+			}
+			else
+			{
+				print '<a class="butActionRefused" href="#" title="'.$langs->trans("NotOwnerOfProject").'">'.$langs->trans('AddTask').'</a>';
+			}
 		}
 		else
 		{
-			print '<a class="butActionRefused" href="#" title="'.$langs->trans("NotOwnerOfProject").'">'.$langs->trans('AddTask').'</a>';
+			print '<a class="butActionRefused" href="#" title="'.$langs->trans("NoPermission").'">'.$langs->trans('AddTask').'</a>';
 		}
-	}
-	elseif( $id_projet)
-	{
-		print '<a class="butActionRefused" href="#" title="'.$langs->trans("NoPermission").'">'.$langs->trans('AddTask').'</a>';
-	}
 
-	print '</div>';
+		print '</div>';
+	}
 ?>
 
 <div>
@@ -517,3 +528,26 @@ td.projectDrag {
 <?php
 
 	llxFooter();
+
+
+
+function _printUserFilter($id_projet, $form)
+{
+	global $conf, $langs, $user;
+
+	if (!empty($conf->global->SCRUM_FILTER_BY_USER_ENABLE))
+	{
+		echo '<tr><td>';
+		echo $langs->trans('UserFilter');
+		echo '</td><td>';
+		$fk_user = GETPOST('fk_user');
+		if (empty($id_projet) && empty($fk_user)) $fk_user = $user->id; // Si on selectionne vide dans le champ on aura -1
+
+		echo '<form action="'.$_SERVER['PHP_SELF'].'" method="POST" id="scrum_filter_by_user">';
+		echo '<input name="id" value="'.$id_projet.'" type="hidden" />';
+		echo $form->select_dolusers($fk_user, 'fk_user',  1);
+		echo '<input type="submit" value="'.$langs->trans('Filter').'" class="butAction" />';
+		echo '</form>';
+		echo '</td></tr>';
+	}
+}


### PR DESCRIPTION
- Retour parmi les vivants de la vue globale, que n'était plus fonctionnelle depuis l'apport des sprints. Elle est désormais splittée par projet puis par sprint
- Empêcher de créer/supprimer/éditer des tâches/sprints depuis la vue globale
- Remettre le filtre par utilisateur sur la vue globale (sachant qu'il était designé pour ça au départ...). La conf associée vaut désormais dans les deux vue (globale et par projet).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atm-consulting/dolibarr_module_scrumboard/38)
<!-- Reviewable:end -->
