### PR TITLE
2.0 - NEW: task ordering by rank, then by rowid

### DIFF
--- a/lib/scrumboard.lib.php
+++ b/lib/scrumboard.lib.php
@@ -270,7 +270,7 @@ function getSQLForTasks(
 		$sql .= ' AND soc.fk_departement = ' . $state_filter;
 	}
 
-	$sql.= ' ORDER BY pt.rang';
+	$sql.= ' ORDER BY pt.rang, pt.rowid';
 
 	return $sql;
 }


### PR DESCRIPTION
## Context
Currently, scrumboard orders tasks by rank only. However, when a project is created automatically (doc2project) or manually, all tasks have the same rank.

## New
If all tasks have the same rank, they will be sorted by rowid, which is more logical for most clients than an unordered task board.