### PR TITLE
FIX tk11329: extrafield filtering no longer functional

### DIFF
--- a/lib/scrumboard.lib.php
+++ b/lib/scrumboard.lib.php
@@ -251,6 +251,7 @@ function getSQLForTasks(
 
 		if (empty($reshook))
 		{
+			$object = $task;
 			// Add where from extra fields
 			include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_sql.tpl.php';
 		}


### PR DESCRIPTION
The boilerplate include file `extrafields_list_search_sql.tpl.php` gets extrafield properties from a variable named `$object`, but that variable was renamed `$task` when the SQL buliding process was moved to a function.