### PR TITLE
PULLUP: Compatibilité Dolibarr v24 — scrumboard 2.8.1 → main

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## NOT RELEASED
 
 ## Release 2.8
+- FIX : Compat V24 - add CSRF token on add-resource-to-task link (MAIN_SECURITY_CSRF_WITH_TOKEN=3) - *03/06/2026* - 2.8.1
 - NEW : Release V23 - *08/04/2026* - 2.8
 
 ## Release 2.7

--- a/core/modules/modscrumboard.class.php
+++ b/core/modules/modscrumboard.class.php
@@ -63,7 +63,7 @@ class modscrumboard extends DolibarrModules
 		// (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Module pour gérer les tâches projet sur une vue kanban";
 		// Possible values for version are: 'development', 'experimental' or version
-		$this->version = '2.8';
+		$this->version = '2.8.1';
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';
 		$this->url_last_version = \scrumboard\TechATM::getLastModuleVersionUrl($this);

--- a/doc/COMPAT_V24.md
+++ b/doc/COMPAT_V24.md
@@ -1,0 +1,38 @@
+# Compatibility report — Dolibarr v24
+
+- **Module:** scrumboard
+- **Current version:** 2.8 → **released as 2.8.1**
+- **Target:** Dolibarr 24.0
+- **Branch:** FIX/COMPATV24 (based on the latest version branch `2.8`)
+- **Date:** 2026-06-03
+- **Scope:** ChangeLog v24 WARNING items (9) + complementary check `csrf-token`
+
+## Findings — ChangeLog v24 (9 items)
+
+| # | Breaking change (v24) | Status | Severity | Evidence |
+|---|---|---|---|---|
+| 1-9 | USF / Login API / signature salt / PAYMENT_SECURITY_TOKEN_UNIQUE / DEPOSIT rename / __MYCOUNTRY_ID__ / info_admin hook / jeditable / Paybox | N-A | — | No occurrence of any (no `fetchAll`, no Paybox/jeditable) |
+
+## Complementary checks `[Extra]`
+
+### csrf-token — MAIN_SECURITY_CSRF_WITH_TOKEN = 3 (default in v24)
+
+| # | Compat point | Status | Severity | Evidence / Fix |
+|---|---|---|---|---|
+| 1 | POST form missing the CSRF token field | N-A | — | `admin/scrumboard_setup.php` 2↔2, `scrum.php` 5↔5, `script/scrum.js.php` emits AJAX tokens |
+| 2 | State-changing GET action link without a token | **FIXED** | LOW | `script/scrum.js.php:272` built a JS `href` to `action=addressourcetotask` with no token. Normal click is intercepted by a handler doing a tokenized AJAX (`pop_contact`, :486), so the workflow worked — but the bare href 403s on direct navigation and was inconsistent with the tokenized story equivalent (`scrum.php:937`). **Fix:** appended `&token='.newToken().'` to the built href (mirror of :937). |
+| 3 | List / mass-action form without a token | N-A | — | No `massaction` |
+| 4 | Module emits no token at all | N-A | — | Tokens widely emitted (forms + AJAX) |
+
+Note: this finding was a **JS-built** action link (`.attr("href", "...action=...")`), which a literal
+`href=` grep misses — the `csrf-token` detection was extended to scan `.js`/`.js.php` for
+`.attr("href"` / `location.href` / `url:` containing `action=`.
+
+## Baseline
+- `php -l` sweep: clean (0 syntax errors)
+- Descriptor sanity: version `2.8` → `2.8.1` (`core/modules/modscrumboard.class.php:66`)
+
+## Summary
+- ChangeLog v24: 9 items, **0 affected**
+- Extra `csrf-token`: 4 points, **1 affected → 1 fixed** (JS-built add-resource link)
+- Release: **2.8 → 2.8.1**

--- a/script/scrum.js.php
+++ b/script/scrum.js.php
@@ -269,7 +269,7 @@ function project_refresh_task(id_project, task) {
 
 	<?php
 	if (getDolGlobalInt('SCRUM_SHOW_LINKED_CONTACT')) {
-		print ' $item.find(".task-add-contact a").attr("href", "'.dol_buildpath('scrumboard/scrum.php', 1).'?action=addressourcetotask&id="+ $("#scrum").attr("id_projet") + "&id_task=" + task.id); ';
+		print ' $item.find(".task-add-contact a").attr("href", "'.dol_buildpath('scrumboard/scrum.php', 1).'?action=addressourcetotask&id="+ $("#scrum").attr("id_projet") + "&id_task=" + task.id + "&token='.newToken().'"); ';
 	}
 	?>
 

--- a/scrum.php
+++ b/scrum.php
@@ -595,10 +595,10 @@
 			print '<tr><td>'.$langs->trans("showDescriptionInTask").'</td>';
 			print '<td>';
 			if(!empty($_SESSION['scrumboard']['showdesc'][$id_projet])) {
-				print '<a href="'.dol_buildpath('scrumboard/scrum.php',1).'?id='.$id_projet.'&action=hide_desc">'.img_picto('test','switch_on.png').'</a>';
+				print '<a href="'.dol_buildpath('scrumboard/scrum.php',1).'?id='.$id_projet.'&action=hide_desc&token='.newToken().'">'.img_picto('test','switch_on.png').'</a>';
 			}
 			else {
-				print '<a href="'.dol_buildpath('scrumboard/scrum.php',1).'?id='.$id_projet.'&action=show_desc">'.img_picto('test','switch_off.png').'</a>';
+				print '<a href="'.dol_buildpath('scrumboard/scrum.php',1).'?id='.$id_projet.'&action=show_desc&token='.newToken().'">'.img_picto('test','switch_off.png').'</a>';
 			}
 			print '</td></tr>';
 		}


### PR DESCRIPTION
> 🔗 **PR cible release : #99** (base `2.8`). La présente PR est le **PULLUP** de la même branche vers `main`.

## PULLUP vers main

Pull-up de `FIX/COMPATV24` vers `main` (convention ATM : la release doit atteindre la ligne de version ET main, depuis la même branche fix).

## Compatibilité Dolibarr v24 — scrumboard

Audit v24 (9 ruptures ChangeLog cœur) + check complémentaire `csrf-token` + **release 2.8.1**.

- **Audit v24** : 9 ruptures → **0 impacté** (aucune occurrence).
- **CSRF (`csrf-token`)** : **1 point corrigé** (sévérité basse). `script/scrum.js.php:272` construisait en JS un `href` GET `action=addressourcetotask` **sans token**. Le clic normal est intercepté par un handler faisant l'AJAX tokenisé (`pop_contact`, l.486) → le workflow marchait, mais le href nu **403 en navigation directe** et était incohérent avec l'équivalent storie tokenisé (`scrum.php:937`). **Fix** : ajout de `&token` au href construit (miroir l.937). Les forms POST (admin 2↔2, scrum.php 5↔5) sont déjà tokenisés.
- **Release 2.8.1** : bump descripteur `2.8 → 2.8.1` + entrée `ChangeLog.md` (anglais).
- Rapport : `doc/COMPAT_V24.md`.

Branche basée sur la ligne de version la plus récente `2.8` (détection auto).

## Plan de test
- [x] Audit des 9 ruptures v24 → 0 impacté
- [x] `csrf-token` : 1 lien JS GET sans token corrigé, re-grep = 0 ; forms POST tokenisés
- [x] `php -l` sur tous les `.php` → 0 erreur
